### PR TITLE
Update / correct licenseInformation at io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -93,7 +93,11 @@
 		"adminUI": {
 			"config": "html"
 		},
-		"license": "MIT",
+		"licenseInformation": {
+			"type": "limited",
+			"license": "CC-BY-NC-ND-4.0",
+			"url": "https://github.com/Zefau/ioBroker.jarvis/discussions/891"
+		},
 		"platform": "Javascript/Node.js",
 		"logTransporter": true,
 		"mode": "daemon",

--- a/io-package.json
+++ b/io-package.json
@@ -96,7 +96,7 @@
 		"licenseInformation": {
 			"type": "limited",
 			"license": "CC-BY-NC-ND-4.0",
-			"url": "https://github.com/Zefau/ioBroker.jarvis/discussions/891"
+			"link": "https://github.com/Zefau/ioBroker.jarvis/discussions/891"
 		},
 		"platform": "Javascript/Node.js",
 		"logTransporter": true,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "yarn": ">= 1.21.1"
   },
   "homepage": "https://github.com/Zefau/ioBroker.jarvis",
-  "license": "MIT",
+  "license": "CC-BY-NC-ND-4.0",
   "main": "jarvis.min.js",
   "name": "iobroker.jarvis",
   "repository": {


### PR DESCRIPTION
Adapters which require a paid license in any way need to set this information at io-package.json. This is done by using common.licenseInformation insatead of common.license.

This PR replaces "license":"MIT" which does not match license at README.md and LICENSE files with CC-BY-NC-NO-4.0 and adds the license type "limited" indicating that the full functionality of this adapter requires a paid pro license.

Please check if "license" is OK and change common.licenseInformtion.link to a link where pricing any shop information is visible.